### PR TITLE
feat: add multi-platform build and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Multi Platform Build and Release System
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code to latest branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup GO running environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Make build script executable
+        run: chmod +x build.sh
+
+      - name: Run build script
+        run: ./build.sh
+
+      - name: List build artifacts
+        run: ls -la wtop-*
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            wtop-windows.exe
+            wtop-linux
+            wtop-macos
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some important notes @SwarnenduG07 

1. Need to add in a github secret token as env variable ( secret ) in the repository named `GITHUB_TOKEN` with permission to make an release.
2. For the workflow to be triggered the last commit should have a tag with version number, i.e `git tag v1.0.0` and then `git push origin v1.0.0` the tag with number would trigger the workflow. So like it doesn't run on every push.

As of now there is no description it will just make the release with proper tag number as the version so that would need updating to have release data ( this could be done but would make it weird if there is too many commits ) however if you want i will push that!